### PR TITLE
Fix order of compare branch and base branch

### DIFF
--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -38,7 +38,7 @@ if (makePretty) {
                         block_id: "commit_title",
                         text: {
                             type: "mrkdwn",
-                            text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchText + "* to *" + compareBranchText + "*." + mentions
+                            text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" + baseBranchText + "*." + mentions
                         }
                     },
                     {
@@ -87,7 +87,7 @@ else if (makeCompact) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchText + "* to *" + compareBranchText + "*." + mentions
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" + baseBranchText + "*." + mentions
                 }
             },
             {

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -87,7 +87,7 @@ else if (makeCompact) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" + baseBranchText + "*." + mentions
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + mentions
                 }
             },
             {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -42,7 +42,7 @@ if (makePretty) {
                         block_id: "commit_title",
                         text: {
                             type: "mrkdwn",
-                            text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchText + "* to *" + compareBranchText + "*." + mentions
+                            text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" + baseBranchText + "*." + mentions
                         }
                     },
                     {
@@ -90,7 +90,7 @@ if (makePretty) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchText + "* to *" + compareBranchText + "*." + mentions
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" + baseBranchText + "*." + mentions
                 }
             },
             {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -90,7 +90,7 @@ if (makePretty) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" + baseBranchText + "*." + mentions
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + mentions
                 }
             },
             {


### PR DESCRIPTION
Wanted to swap the order of `compareBranchText` and `baseBranchText` for pretty mode and remove for compact mode. Is there anything needed here to bump the version number @johnmarriott?